### PR TITLE
use NavState instead of NavIndex for scoring

### DIFF
--- a/examples/Example1/include/SensitiveDetector.hh
+++ b/examples/Example1/include/SensitiveDetector.hh
@@ -32,6 +32,7 @@
 #include "SimpleHit.hh"
 
 #include "G4VSensitiveDetector.hh"
+#include <set>
 
 class G4HCofThisEvent;
 class G4TouchableHistory;

--- a/examples/IntegrationBenchmark/include/SensitiveDetector.hh
+++ b/examples/IntegrationBenchmark/include/SensitiveDetector.hh
@@ -33,6 +33,7 @@
 
 #include "G4VFastSimSensitiveDetector.hh"
 #include "G4VSensitiveDetector.hh"
+#include <set>
 
 class G4HCofThisEvent;
 class G4TouchableHistory;

--- a/include/AdePT/core/HostScoringImpl.cuh
+++ b/include/AdePT/core/HostScoringImpl.cuh
@@ -169,14 +169,14 @@ namespace adept_scoring
     aGPUHit->fStepLength         = aStepLength;
     aGPUHit->fTotalEnergyDeposit = aTotalEnergyDeposit;
     // Pre step point
-    aGPUHit->fPreStepPoint.fNavigationStateIndex = aPreState->GetNavIndex();
+    aGPUHit->fPreStepPoint.fNavigationState = *aPreState;
     Copy3DVector(aPrePosition, &(aGPUHit->fPreStepPoint.fPosition));
     Copy3DVector(aPreMomentumDirection, &(aGPUHit->fPreStepPoint.fMomentumDirection));
     // Copy3DVector(aPrePolarization, aGPUHit.fPreStepPoint.fPolarization);
     aGPUHit->fPreStepPoint.fEKin   = aPreEKin;
     aGPUHit->fPreStepPoint.fCharge = aPreCharge;
     // Post step point
-    aGPUHit->fPostStepPoint.fNavigationStateIndex = aPostState->GetNavIndex();
+    aGPUHit->fPostStepPoint.fNavigationState = *aPostState;
     Copy3DVector(aPostPosition, &(aGPUHit->fPostStepPoint.fPosition));
     Copy3DVector(aPostMomentumDirection, &(aGPUHit->fPostStepPoint.fMomentumDirection));
     // Copy3DVector(aPostPolarization, aGPUHit.fPostStepPoint.fPolarization);

--- a/include/AdePT/core/HostScoringStruct.cuh
+++ b/include/AdePT/core/HostScoringStruct.cuh
@@ -15,7 +15,7 @@ struct GPUStepPoint {
   double fEKin;
   double fCharge;
   // Data needed to reconstruct G4 Touchable history
-  NavIndex_t fNavigationStateIndex{0}; // VecGeom navigation state index, used to identify the touchable
+  vecgeom::NavigationState fNavigationState{0}; // VecGeom navigation state, used to identify the touchable
 };
 
 // Stores the necessary data to reconstruct GPU hits on the host , and

--- a/include/AdePT/integration/AdePTGeant4Integration.hh
+++ b/include/AdePT/integration/AdePTGeant4Integration.hh
@@ -63,7 +63,7 @@ public:
 
 private:
   /// @brief Reconstruct G4TouchableHistory from a VecGeom Navigation index
-  void FillG4NavigationHistory(unsigned int aNavIndex, G4NavigationHistory *aG4NavigationHistory);
+  void FillG4NavigationHistory(vecgeom::NavigationState aNavState, G4NavigationHistory *aG4NavigationHistory);
 
   void FillG4Step(GPUHit *aGPUHit, G4Step *aG4Step, G4TouchableHandle &aPreG4TouchableHandle,
                   G4TouchableHandle &aPostG4TouchableHandle);

--- a/include/AdePT/kernels/electrons.cuh
+++ b/include/AdePT/kernels/electrons.cuh
@@ -314,10 +314,10 @@ static __device__ __forceinline__ void TransportElectrons(adept::TrackManager<Tr
       if (!nextState.IsOutside()) {
 #ifdef ADEPT_USE_SURF
         AdePTNavigator::RelocateToNextVolume(pos, dir, hitsurf_index, nextState);
+        if (nextState.IsOutside()) continue;
 #else
         AdePTNavigator::RelocateToNextVolume(pos, dir, nextState);
 #endif
-        if (nextState.IsOutside()) continue;
         // Move to the next boundary.
         navState = nextState;
         // Check if the next volume belongs to the GPU region and push it to the appropriate queue

--- a/include/AdePT/kernels/electrons.cuh
+++ b/include/AdePT/kernels/electrons.cuh
@@ -313,10 +313,11 @@ static __device__ __forceinline__ void TransportElectrons(adept::TrackManager<Tr
       // Kill the particle if it left the world.
       if (!nextState.IsOutside()) {
 #ifdef ADEPT_USE_SURF
-        AdePTNavigator::RelocateToNextVolume(pos, dir, hitsurf_index, nextState); 
+        AdePTNavigator::RelocateToNextVolume(pos, dir, hitsurf_index, nextState);
 #else
         AdePTNavigator::RelocateToNextVolume(pos, dir, nextState);
 #endif
+        if (nextState.IsOutside()) continue;
         // Move to the next boundary.
         navState = nextState;
         // Check if the next volume belongs to the GPU region and push it to the appropriate queue

--- a/include/AdePT/kernels/gammas.cuh
+++ b/include/AdePT/kernels/gammas.cuh
@@ -131,10 +131,10 @@ __global__ void TransportGammas(adept::TrackManager<Track> *gammas, Secondaries 
       if (!nextState.IsOutside()) {
 #ifdef ADEPT_USE_SURF
         AdePTNavigator::RelocateToNextVolume(pos, dir, hitsurf_index, nextState); 
+        if (nextState.IsOutside()) continue;
 #else
         AdePTNavigator::RelocateToNextVolume(pos, dir, nextState);
 #endif
-        if (nextState.IsOutside()) continue;
         // Move to the next boundary.
         navState = nextState;
         //printf("  -> pvol=%d pos={%g, %g, %g} \n", navState.TopId(), pos[0], pos[1], pos[2]);

--- a/include/AdePT/kernels/gammas.cuh
+++ b/include/AdePT/kernels/gammas.cuh
@@ -134,6 +134,7 @@ __global__ void TransportGammas(adept::TrackManager<Track> *gammas, Secondaries 
 #else
         AdePTNavigator::RelocateToNextVolume(pos, dir, nextState);
 #endif
+        if (nextState.IsOutside()) continue;
         // Move to the next boundary.
         navState = nextState;
         //printf("  -> pvol=%d pos={%g, %g, %g} \n", navState.TopId(), pos[0], pos[1], pos[2]);

--- a/src/AdePTGeant4Integration.cpp
+++ b/src/AdePTGeant4Integration.cpp
@@ -34,6 +34,7 @@ void AdePTGeant4Integration::CreateVecGeomWorld(std::string filename)
 {
   // Import the gdml file into VecGeom
   vecgeom::GeoManager::Instance().SetTransformationCacheDepth(0);
+  vecgeom::GeoManager::Instance().SetMinPerScene(1);
   vgdml::Parser vgdmlParser;
   auto middleWare = vgdmlParser.Load(filename, false, mm);
   if (middleWare == nullptr) {
@@ -280,13 +281,13 @@ void AdePTGeant4Integration::ProcessGPUHits(HostScoring &aScoring, HostScoring::
     // Get Hit index (Circular buffer)
     int aHitIdx = i % aScoring.fBufferCapacity;
 
-    int aNavindex = aScoring.fGPUHitsBuffer_host[aHitIdx].fPreStepPoint.fNavigationStateIndex;
+    vecgeom::NavigationState &aNavState = aScoring.fGPUHitsBuffer_host[aHitIdx].fPreStepPoint.fNavigationState;
     // Reconstruct Pre-Step point G4NavigationHistory
-    FillG4NavigationHistory(aNavindex, fPreG4NavigationHistory);
+    FillG4NavigationHistory(aNavState, fPreG4NavigationHistory);
     ((G4TouchableHistory *)fPreG4TouchableHistoryHandle())
         ->UpdateYourself(fPreG4NavigationHistory->GetTopVolume(), fPreG4NavigationHistory);
     // Reconstruct Post-Step point G4NavigationHistory
-    FillG4NavigationHistory(aNavindex, fPostG4NavigationHistory);
+    FillG4NavigationHistory(aNavState, fPostG4NavigationHistory);
     ((G4TouchableHistory *)fPostG4TouchableHistoryHandle())
         ->UpdateYourself(fPostG4NavigationHistory->GetTopVolume(), fPostG4NavigationHistory);
 
@@ -317,13 +318,12 @@ void AdePTGeant4Integration::ProcessGPUHits(HostScoring &aScoring, HostScoring::
   }
 }
 
-void AdePTGeant4Integration::FillG4NavigationHistory(unsigned int aNavIndex, G4NavigationHistory *aG4NavigationHistory)
+void AdePTGeant4Integration::FillG4NavigationHistory(vecgeom::NavigationState aNavState, G4NavigationHistory *aG4NavigationHistory)
 {
   // Get the current depth of the history (corresponding to the previous reconstructed touchable)
   auto aG4HistoryDepth = aG4NavigationHistory->GetDepth();
   // Get the depth of the navigation state we want to reconstruct
-  vecgeom::NavigationState vgState(aNavIndex);
-  auto aVecGeomLevel = vgState.GetLevel();
+  auto aVecGeomLevel = aNavState.GetLevel();
 
   unsigned int aLevel{0};
   G4VPhysicalVolume *pvol{nullptr}, *pnewvol{nullptr};
@@ -331,7 +331,7 @@ void AdePTGeant4Integration::FillG4NavigationHistory(unsigned int aNavIndex, G4N
   for (aLevel = 0; aLevel <= aVecGeomLevel; aLevel++) {
     // While we are in levels shallower than the history depth, it may be that we already
     // have the correct volume in the history
-    pnewvol = const_cast<G4VPhysicalVolume *>(fglobal_vecgeom_to_g4_map[vgState.At(aLevel)->id()]);
+    pnewvol = const_cast<G4VPhysicalVolume *>(fglobal_vecgeom_to_g4_map[aNavState.At(aLevel)->id()]);
 
     if (aG4HistoryDepth && (aLevel <= aG4HistoryDepth)) {
       pvol = aG4NavigationHistory->GetVolume(aLevel);

--- a/src/AdePTGeant4Integration.cpp
+++ b/src/AdePTGeant4Integration.cpp
@@ -34,7 +34,6 @@ void AdePTGeant4Integration::CreateVecGeomWorld(std::string filename)
 {
   // Import the gdml file into VecGeom
   vecgeom::GeoManager::Instance().SetTransformationCacheDepth(0);
-  vecgeom::GeoManager::Instance().SetMinPerScene(1);
   vgdml::Parser vgdmlParser;
   auto middleWare = vgdmlParser.Load(filename, false, mm);
   if (middleWare == nullptr) {


### PR DESCRIPTION
The full state needs to be saved instead of just the NavStateIndex, because when using NavTuple, otherwise the state of higher level scenes are not reconstructed correctly (e.g., they end up as `navInd=s1:29, id=1, level=1/3,  onBoundary=false, path=</TOP_SCENE | /box_1>`). This PR fixes the issue. Now the NavTuple works with surfaces, but still stalls for Solids in the test beam setup.

Furthermore, <set> was included as AdePT didn't compile with GCC 11.4 otherwise.